### PR TITLE
Simplify buildsystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - ./travis/download-deps.py
 script:
   - flatpak-builder --ccache --stop-at=almond-gnome --force-clean _app/ edu.stanford.Almond.json
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app --share=network yarn
+  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 --share=network _app yarn
   - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app yarn --offline lint
   - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app meson --prefix=/app _build
   - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
   - ./travis/download-deps.py
 script:
   - flatpak-builder --ccache --stop-at=almond-gnome --force-clean _app/ edu.stanford.Almond.json
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app yarn
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app yarn lint
+  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app --share=network yarn
+  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app yarn --offline lint
   - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app meson --prefix=/app _build
   - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build
   - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build install >/dev/null 2>&1

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,3 @@
 build_from_source true
 sqlite_libname sqlcipher
 sqlite /usr
-yarn-offline-mirror "./deps"

--- a/meson/copy_service_to_builddir.py
+++ b/meson/copy_service_to_builddir.py
@@ -50,12 +50,11 @@ recurse('.')
 shutil.copy2(os.path.join(rootsrcdir, 'package.json'), os.path.join(builddir, 'package.json'))
 shutil.copy2(os.path.join(rootsrcdir, 'yarn.lock'), os.path.join(builddir, 'yarn.lock'))
 shutil.copy2(os.path.join(rootsrcdir, '.yarnrc'), os.path.join(builddir, '.yarnrc'))
-try:
-    os.unlink(os.path.join(builddir, 'deps'))
-except FileNotFoundError:
-    pass
-os.symlink(os.path.relpath(os.path.join(rootsrcdir, 'deps'), builddir), os.path.join(builddir, 'deps'))
+with open(os.path.join(builddir, '.yarnrc'), 'a') as fp:
+    depsdir = os.path.abspath(os.path.join(rootsrcdir, 'deps'))
+    print(f'yarn-offline-mirror "{depsdir}"', file=fp)
 
 yarn = os.environ.get('YARN', 'yarn')
+print(os.path.abspath(builddir))
 subprocess.check_call([yarn, "install", "--offline", "--only=production", "--frozen-lockfile"], cwd=builddir)
 

--- a/meson/meson_post_install.py
+++ b/meson/meson_post_install.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import shutil
 import pathlib
 import subprocess
 

--- a/meson/meson_post_install.py
+++ b/meson/meson_post_install.py
@@ -18,6 +18,3 @@ if not destdir:
 
     print('Updating desktop database...')
     subprocess.call(['update-desktop-database', '-q', str(datadir / 'applications')])
-
-servicedir = os.path.join(os.environ.get('MESON_DESTDIR_INSTALL_PREFIX', os.environ['MESON_INSTALL_PREFIX']), 'lib', 'edu.stanford.Almond', 'service')
-shutil.rmtree(os.path.join(servicedir, "deps"))


### PR DESCRIPTION
We can avoid the dance of symlinking dest and copying it and removing
it by pointing yarn to the right place in the source directory