### PR TITLE
Stop building node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - sudo apt-get install -y flatpak-builder elfutils
   - flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-  - flatpak --user install -y flathub org.gnome.Sdk//3.32 org.gnome.Platform//3.32 org.freedesktop.Sdk.Extension.openjdk11//18.08
+  - flatpak --user install -y flathub org.gnome.Sdk//3.32 org.gnome.Platform//3.32 org.freedesktop.Sdk.Extension.openjdk11//18.08 org.freedesktop.Sdk.Extension.node10//18.08
   - curl -O https://crowdie.stanford.edu/flatpak/build-cache.tar.gz
   - tar xf build-cache.tar.gz
   - ./travis/download-deps.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ install:
   - ./travis/download-deps.py
 script:
   - flatpak-builder --ccache --stop-at=almond-gnome --force-clean _app/ edu.stanford.Almond.json
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 --share=network _app yarn
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app yarn --offline lint
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app meson --prefix=/app _build
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build
-  - flatpak build --env=npm_config_nodedir=/app --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build install >/dev/null 2>&1
+  - flatpak build --env=npm_config_nodedir=/usr/lib/sdk/node10 --env=PYTHONDONTWRITEBYTECODE=1 --share=network _app yarn
+  - flatpak build --env=npm_config_nodedir=/usr/lib/sdk/node10 --env=PYTHONDONTWRITEBYTECODE=1 _app yarn --offline lint
+  - flatpak build --env=npm_config_nodedir=/usr/lib/sdk/node10 --env=PYTHONDONTWRITEBYTECODE=1 _app meson --prefix=/app _build
+  - flatpak build --env=npm_config_nodedir=/usr/lib/sdk/node10 --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build
+  - flatpak build --env=npm_config_nodedir=/usr/lib/sdk/node10 --env=PYTHONDONTWRITEBYTECODE=1 _app ninja -C _build install >/dev/null 2>&1
   - flatpak-builder --finish-only --repo=_repo _app edu.stanford.Almond.json
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - sudo apt-get install -y flatpak-builder elfutils
   - flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-  - flatpak --user install -y flathub org.gnome.Sdk//3.32 org.gnome.Platform//3.32 org.freedesktop.Sdk.Extension.openjdk11//18.08 org.freedesktop.Sdk.Extension.node10//18.08
+  - flatpak --user install -y flathub org.gnome.Sdk//3.34 org.gnome.Platform//3.34 org.freedesktop.Sdk.Extension.openjdk11//19.08 org.freedesktop.Sdk.Extension.node10//19.08
   - curl -O https://crowdie.stanford.edu/flatpak/build-cache.tar.gz
   - tar xf build-cache.tar.gz
   - ./travis/download-deps.py

--- a/build-data/grpc_rename_gettid.patch
+++ b/build-data/grpc_rename_gettid.patch
@@ -1,0 +1,79 @@
+From d1d017390b799c59d6fdf7b8afa6136d218bdd61 Mon Sep 17 00:00:00 2001
+From: Benjamin Peterson <benjamin@dropbox.com>
+Date: Fri, 3 May 2019 08:11:00 -0700
+Subject: [PATCH] Rename gettid() functions.
+
+glibc 2.30 will declare its own gettid; see https://sourceware.org/git/?p=glibc.git;a=commit;h=1d0fc213824eaa2a8f8c4385daaa698ee8fb7c92. Rename the grpc versions to avoid naming conflicts.
+---
+ src/core/lib/gpr/log_linux.cc          | 4 ++--
+ src/core/lib/gpr/log_posix.cc          | 4 ++--
+ src/core/lib/iomgr/ev_epollex_linux.cc | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git src/core/lib/gpr/log_linux.cc.orig src/core/lib/gpr/log_linux.cc
+index 561276f0c20..8b597b4cf2f 100644
+--- src/core/lib/gpr/log_linux.cc.orig	2019-06-21 10:42:13.235611417 -0400
++++ src/core/lib/gpr/log_linux.cc	2019-06-21 10:42:16.686608855 -0400
+@@ -40,7 +40,7 @@
+ #include <time.h>
+ #include <unistd.h>
+ 
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long sys_gettid(void) { return syscall(__NR_gettid); }
+ 
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -70,7 +70,7 @@ void gpr_default_log(gpr_log_func_args*
+   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
+   struct tm tm;
+   static __thread long tid = 0;
+-  if (tid == 0) tid = gettid();
++  if (tid == 0) tid = sys_gettid();
+ 
+   timer = static_cast<time_t>(now.tv_sec);
+   final_slash = strrchr(args->file, '/');
+diff --git src/core/lib/gpr/log_posix.cc.orig src/core/lib/gpr/log_posix.cc
+index b6edc14ab6b..2f7c6ce3760 100644
+--- src/core/lib/gpr/log_posix.cc.orig	2019-06-21 10:42:13.242611412 -0400
++++ src/core/lib/gpr/log_posix.cc	2019-06-21 10:42:22.794604319 -0400
+@@ -30,7 +30,7 @@
+ #include <string.h>
+ #include <time.h>
+ 
+-static intptr_t gettid(void) { return (intptr_t)pthread_self(); }
++static intptr_t sys_gettid(void) { return (intptr_t)pthread_self(); }
+ 
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -85,7 +85,7 @@ void gpr_default_log(gpr_log_func_args*
+   char* prefix;
+   gpr_asprintf(&prefix, "%s%s.%09d %7tu %s:%d]",
+                gpr_log_severity_string(args->severity), time_buffer,
+-               (int)(now.tv_nsec), gettid(), display_file, args->line);
++               (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
+ 
+   fprintf(stderr, "%-70s %s\n", prefix, args->message);
+   gpr_free(prefix);
+diff --git src/core/lib/iomgr/ev_epollex_linux.cc.orig src/core/lib/iomgr/ev_epollex_linux.cc
+index 08116b3ab53..76f59844312 100644
+--- src/core/lib/iomgr/ev_epollex_linux.cc.orig	2019-06-21 10:42:13.247611408 -0400
++++ src/core/lib/iomgr/ev_epollex_linux.cc	2019-06-21 10:42:29.767599141 -0400
+@@ -1150,7 +1150,7 @@ static void end_worker(grpc_pollset* pol
+ }
+ 
+ #ifndef NDEBUG
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long sys_gettid(void) { return syscall(__NR_gettid); }
+ #endif
+ 
+ /* pollset->mu lock must be held by the caller before calling this.
+@@ -1170,7 +1170,7 @@ static grpc_error* pollset_work(grpc_pol
+ #define WORKER_PTR (&worker)
+ #endif
+ #ifndef NDEBUG
+-  WORKER_PTR->originator = gettid();
++  WORKER_PTR->originator = sys_gettid();
+ #endif
+   if (grpc_polling_trace.enabled()) {
+     gpr_log(GPR_INFO,
+

--- a/build-data/python3-attrs.json
+++ b/build-data/python3-attrs.json
@@ -2,7 +2,8 @@
     "name": "python3-attrs",
     "buildsystem": "simple",
     "build-commands": [
-        "python3 ./setup.py install --prefix=${FLATPAK_DEST}"
+        "python3 ./setup.py install --prefix=${FLATPAK_DEST}",
+        "rm /app/lib/python3.7/site-packages/easy-install.pth"
     ],
     "sources": [
         {

--- a/build-data/python3-tensorflow-deps.json
+++ b/build-data/python3-tensorflow-deps.json
@@ -2,7 +2,7 @@
     "name": "python3-tensorflow-deps",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} absl-py astor gast keras_applications keras_preprocessing protobuf tensorboard tensorflow_estimator termcolor grpcio wheel"
+        "pip3 install --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} absl-py astor gast keras_applications keras_preprocessing protobuf tensorboard tensorflow_estimator termcolor wheel"
     ],
     "build-options": {
         "env": {
@@ -52,11 +52,6 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/da/3f/9b0355080b81b15ba6a9ffcf1f5ea39e307a2778b2f2dc8694724e8abd5b/absl-py-0.7.1.tar.gz",
             "sha256": "b943d1c567743ed0455878fcd60bc28ac9fae38d129d1ccfad58079da00b8951"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e3/aa/6ee1f1c0b35d270725abff07f8d807c0413154af14cd019fd3aa3ab69d64/grpcio-1.19.0.tar.gz",
-            "sha256": "2ddbca16c2e7b3f2ffc6e34c7cfa6886fb01de9f156ad3f77b72ad652d632097"
         },
         {
             "type": "file",

--- a/build-data/tensorflow.bazelrc
+++ b/build-data/tensorflow.bazelrc
@@ -7,7 +7,9 @@ build --action_env TF_NEED_OPENCL_SYCL="0"
 build --action_env TF_NEED_ROCM="0"
 build --action_env TF_NEED_CUDA="0"
 build --action_env TF_DOWNLOAD_CLANG="0"
-build --action_env TF_SYSTEM_LIBS="boringssl,icu,pcre,zlib_archive,gif_archive,png_archive,jpeg,curl"
+build --action_env TF_SYSTEM_LIBS="boringssl,icu,pcre,zlib_archive,gif_archive,png_archive,jpeg,curl,grpc,cython"
+build --linkopt=-L/app/lib
+build --host_linkopt=-L/app/lib
 build:opt --copt=-Wno-sign-compare
 build:opt --host_copt=-march=native
 build:opt --define with_default_optimizations=true

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -4,7 +4,8 @@
     "runtime-version" : "3.32",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
-        "org.freedesktop.Sdk.Extension.openjdk11"
+        "org.freedesktop.Sdk.Extension.openjdk11",
+        "org.freedesktop.Sdk.Extension.node10"
     ],
     "command" : "/app/bin/edu.stanford.Almond",
     "tags" : [
@@ -209,19 +210,8 @@
         },
         {
             "name" : "node",
-            "config-opts" : [
-                "--openssl-use-def-ca-store",
-                "--shared-openssl",
-                "--shared-zlib",
-                "--with-intl=system-icu"
-            ],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "sha256" : "7bf1123d7415964775b8f81fe6ec6dd5c3c08abb42bb71dfe4409dbeeba26bbd",
-                    "url" : "https://nodejs.org/dist/v10.16.3/node-v10.16.3.tar.xz"
-                }
-            ]
+            "buildsystem" : "simple",
+            "build-commands" : [ "/usr/lib/sdk/node10/install.sh" ]
         },
         {
             "name" : "yarn",
@@ -426,8 +416,10 @@
             "name" : "almond-gnome",
             "buildsystem" : "meson",
             "build-options" : {
+                "append-path": "/usr/lib/sdk/node10/bin",
+                "append-ld-library-path": "/usr/lib/sdk/node10/lib",
                 "env" : {
-                    "npm_config_nodedir" : "/app"
+                    "npm_config_nodedir" : "/usr/lib/sdk/node10"
                 }
             },
             "sources" : [

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -211,7 +211,9 @@
         {
             "name" : "node",
             "buildsystem" : "simple",
-            "build-commands" : [ "/usr/lib/sdk/node10/install.sh" ]
+            "build-commands" : [
+                "install -Dm 755 /usr/lib/sdk/node10/bin/node /app/bin/node"
+            ]
         },
         {
             "name" : "yarn",
@@ -416,8 +418,6 @@
             "name" : "almond-gnome",
             "buildsystem" : "meson",
             "build-options" : {
-                "append-path": "/usr/lib/sdk/node10/bin",
-                "append-ld-library-path": "/usr/lib/sdk/node10/lib",
                 "env" : {
                     "npm_config_nodedir" : "/usr/lib/sdk/node10"
                 }

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "edu.stanford.Almond",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.32",
+    "runtime-version" : "3.34",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.openjdk11",
@@ -300,15 +300,17 @@
             "name" : "bazel",
             "buildsystem": "simple",
             "build-commands": [
+                "ln -s /usr/bin/python3 /app/bin/python",
                 "./compile.sh",
-                "install -m 0755 -D output/bazel /app/bin/bazel"
+                "install -m 0755 -D output/bazel /app/bin/bazel",
+                "rm /app/bin/python"
             ],
             "build-options": {
                 "strip": false,
                 "no-debuginfo": true,
                 "no-debuginfo-compression": true,
                 "env" : {
-                    "EXTRA_BAZEL_ARGS": "--host_javabase=@local_jdk//:jdk",
+                    "EXTRA_BAZEL_ARGS": "--host_javabase=@local_jdk//:jdk --python_path=/usr/bin/python3",
                     "JAVA_HOME": "/usr/lib/sdk/openjdk11/jvm/openjdk-11"
                 }
             },
@@ -318,6 +320,12 @@
                     "url": "https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel-0.29.1-dist.zip",
                     "sha256": "872a52cff208676e1169b3e1cae71b1fe572c4109cbd66eab107d8607c378de5",
                     "strip-components": 0
+                },
+                {
+                    "type": "patch",
+                    "path": "build-data/grpc_rename_gettid.patch",
+                    "strip-components": 0,
+                    "options": [ "-d", "third_party/grpc" ]
                 }
             ]
         },
@@ -334,6 +342,38 @@
         "./build-data/python3-prettyparse.json",
         "./build-data/python3-typing.json",
         "./build-data/python3-attrs.json",
+        {
+            "name": "grpc",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make prefix=/app",
+                "make prefix=/app install",
+                "python3 setup.py install --prefix=/app",
+                "rm /app/lib/libgrpc*.a",
+                "rm /app/lib/python3.7/site-packages/easy-install.pth"
+            ],
+            "build-options" : {
+                "env" : {
+                    "CFLAGS" : "-g -O2 -Wno-error",
+                    "CXXFLAGS" : "-g -O2 -Wno-error",
+                    "GRPC_PYTHON_BUILD_WITH_CYTHON": "True",
+                    "GRPC_PYTHON_BUILD_SYSTEM_OPENSSL": "True",
+                    "GRPC_PYTHON_BUILD_SYSTEM_ZLIB": "True"
+                }
+            },
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/grpc/grpc",
+                    "commit": "4566c2a29ebec0835643b972eb99f4306c4234a3"
+                },
+                {
+                    "type": "patch",
+                    "path": "build-data/grpc_rename_gettid.patch",
+                    "strip-components": 0
+                }
+            ]
+        },
         "./build-data/python3-tensorflow-deps.json",
         "./build-data/python3-keras.json",
         "./build-data/python3-wrapt.json",
@@ -343,9 +383,11 @@
             "build-commands": [
                 "mkdir -p tensorflow_pkg",
                 "mkdir -p /run/ccache/bazel",
+                "ln -s /usr/bin/python3 /app/bin/python",
                 "bazel --output_user_root=/run/ccache/bazel build --incompatible_no_support_tools_in_action_inputs=false --distdir=\"${PWD}/bazel-distdir\" --config=opt --config=nogcp --config=noaws --config=nohdfs --config=noignite --config=nokafka //tensorflow/tools/pip_package:build_pip_package",
                 "PYTHON_BIN_PATH=/usr/bin/python3 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package tensorflow_pkg/",
-                "pip3 install --no-index --no-build-isolation --prefix=/app --no-deps tensorflow_pkg/tensorflow-*.whl"
+                "pip3 install --no-index --no-build-isolation --prefix=/app --no-deps tensorflow_pkg/tensorflow-*.whl",
+                "rm /app/bin/python"
             ],
             "build-options": {
                 "env" : {
@@ -373,9 +415,11 @@
             "build-commands": [
                 "mkdir -p tensorflow_estimator_pkg",
                 "mkdir -p /run/ccache/bazel",
+                "ln -s /usr/bin/python3 /app/bin/python",
                 "bazel --output_user_root=/run/ccache/bazel build --incompatible_no_support_tools_in_action_inputs=false --distdir=\"${PWD}/bazel-distdir\" //tensorflow_estimator/tools/pip_package:build_pip_package",
                 "PYTHON_BIN_PATH=/usr/bin/python3 ./bazel-bin/tensorflow_estimator/tools/pip_package/build_pip_package tensorflow_estimator_pkg/",
-                "pip3 install --no-index --no-build-isolation --prefix=/app tensorflow_estimator_pkg/tensorflow_estimator-*.whl"
+                "pip3 install --no-index --no-build-isolation --prefix=/app tensorflow_estimator_pkg/tensorflow_estimator-*.whl",
+                "rm /app/bin/python"
             ],
             "build-options": {
                 "env" : {


### PR DESCRIPTION
Use the prebuilt version from the node10 SDK extension. This way, we ship the same exact binary as all other node using apps (including all the Electron apps) which reduces disk usage.