### PR TITLE
Install freedesktop sound theme

### DIFF
--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -463,6 +463,16 @@
             ]
         },
         {
+            "name" : "sound-theme-freedesktop",
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "http://people.freedesktop.org/~mccann/dist/sound-theme-freedesktop-0.8.tar.bz2",
+                    "sha256": "cb518b20eef05ec2e82dda1fa89a292c1760dc023aba91b8aa69bafac85e8a14"
+                }
+            ]
+        },
+        {
             "name" : "almond-gnome",
             "buildsystem" : "meson",
             "build-options" : {

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -463,6 +463,19 @@
             ]
         },
         {
+            "name" : "intltool",
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "http://edge.launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "sha256" : "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+                }
+            ],
+            "cleanup": [
+                "/*"
+            ]
+        },
+        {
             "name" : "sound-theme-freedesktop",
             "sources": [
                 {


### PR DESCRIPTION
Required for the "hotword detected" sound effect, as well as other
sound effects, and no longer installed by default in the runtime