### PR TITLE
flatpak: build with -Wl,--no-as-needed

### DIFF
--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -291,13 +291,11 @@
             "buildsystem" : "meson",
             "build-options" : {
                 "env" : {
-                    "npm_config_nodedir" : "/usr/lib/sdk/node10"
+                    "npm_config_nodedir" : "/usr/lib/sdk/node10",
+                    "LDFLAGS": "-L/app/lib -Wl,-z,relro,-z,now -Wl,--no-as-needed"
                 },
                 "append-path": "/usr/lib/sdk/node10/bin"
             },
-            "cleanup": [
-                "/lib/node_modules"
-            ],
             "sources" : [
                 {
                     "type" : "git",

--- a/meson/copy_service_to_builddir.py
+++ b/meson/copy_service_to_builddir.py
@@ -56,5 +56,4 @@ with open(os.path.join(builddir, '.yarnrc'), 'a') as fp:
 
 yarn = os.environ.get('YARN', 'yarn')
 print(os.path.abspath(builddir))
-subprocess.check_call([yarn, "install", "--offline", "--only=production", "--frozen-lockfile"], cwd=builddir)
-
+subprocess.check_call([yarn, "install", "--offline", "--only=production", "--frozen-lockfile", "--noprogress"], cwd=builddir)

--- a/shell-extension/extension.js
+++ b/shell-extension/extension.js
@@ -469,7 +469,7 @@ const AssistantSource = GObject.registerClass(class AssistantSource extends Mess
         this._notification.setUrgency(MessageTray.Urgency.HIGH);
         this._notification.setResident(true);
 
-        this._notification.model = model;
+        this._notification.model = this._model;
         this._notification.connect('activated', this.open.bind(this));
         this._notification.connect('updated', () => {
             //if (this._banner && this._banner.expanded)


### PR DESCRIPTION
snowboy builds incorrectly otherwise, because -lcblas is listed
before the library that uses cblas on the commandline.
--as-needed is a bad idea anyway: if you don't want to link to a
library, don't tell the linker to link to it!